### PR TITLE
Update license to standard license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,7 @@
-This software released into the public domain. Anyone is free to copy,
-modify, publish, use, compile, sell, or distribute this software,
-either in source code form or as a compiled binary, for any purpose,
-commercial or non-commercial, and by any means.
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
The current license is none specified in the [SPDX specification](https://spdx.org/licenses/).
While not a huge problem, this makes automation building on common license standards hard.

If you are fine with using the standard "[Unlicense](https://spdx.org/licenses/Unlicense.html)" (which is commonly used as a standard `Public Domain` license, this could help people doing such work with licenses.

I am happy to update the `conda-forge` feedstock, in case you are open to this change.